### PR TITLE
feat: Add context window reduction + cleaning caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+opencode.json
+
 # hatch-vcs
 conda_meta_mcp/_version.py
 

--- a/conda_meta_mcp/tools/__init__.py
+++ b/conda_meta_mcp/tools/__init__.py
@@ -1,3 +1,4 @@
+from .cache_utils import register_cache_maintenance
 from .cli_help import register_cli_help
 from .import_mapping import register_import_mapping
 from .info import register_info
@@ -14,6 +15,7 @@ TOOLS = [
     register_repoquery,
     register_import_mapping,
     register_pypi_to_conda,
+    register_cache_maintenance,
 ]
 
 __all__ = ["TOOLS"]

--- a/conda_meta_mcp/tools/cache_utils.py
+++ b/conda_meta_mcp/tools/cache_utils.py
@@ -1,0 +1,41 @@
+"""Minimal external cache clearing registry and on-demand MCP tool."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import suppress
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+T = TypeVar("T")
+
+ExternalCacheClearer = Callable[[], None]
+_external_cache_clearers: list[ExternalCacheClearer] = []
+
+
+def register_external_cache_clearer(clearer: ExternalCacheClearer) -> None:
+    """Register a callback that clears external or tool-level caches."""
+    _external_cache_clearers.append(clearer)
+
+
+def clear_external_library_caches() -> None:
+    """Call all registered cache clearers (best-effort; ignore their errors)."""
+    for clearer in list(_external_cache_clearers):
+        with suppress(Exception):
+            clearer()
+
+
+def register_cache_maintenance(mcp: FastMCP) -> None:
+    """Register an MCP tool to trigger cache maintenance on demand."""
+
+    @mcp.tool
+    async def cache_maintenance() -> str:
+        """
+        Run cache maintenance for all registered external and tool-level caches.
+
+        Returns a short status message after cleanup has been triggered.
+        """
+        clear_external_library_caches()
+        return "External and tool-level caches cleared."

--- a/conda_meta_mcp/tools/cli_help.py
+++ b/conda_meta_mcp/tools/cli_help.py
@@ -7,6 +7,7 @@ Currently based on https://github.com/praiskup/argparse-manpage
 from __future__ import annotations
 
 import asyncio
+import re
 from functools import cache
 from typing import TYPE_CHECKING
 
@@ -24,10 +25,21 @@ def _get_conda_help() -> str:
     return str(Manpage(generate_parser(add_help=True, prog="conda")))
 
 
-def _cli_help(tool: str = "conda", limit: int = 0, offset: int = 0) -> str:
+def _cli_help(tool: str = "conda", limit: int = 0, offset: int = 0, grep: str = "") -> str:
     match tool:
         case "conda":
             lines = _get_conda_help().splitlines()
+
+            # Apply regex filtering if grep is provided
+            if grep and grep.strip():
+                try:
+                    pattern = re.compile(grep, re.IGNORECASE)
+                    lines = [line for line in lines if pattern.search(line)]
+                except re.error as e:
+                    raise ToolError(f"Invalid regex pattern: {e}") from e
+
+            # Apply pagination
+            offset = max(offset or 0, 0)
             lines = lines[offset : offset + limit] if limit and limit > 0 else lines[offset:]
             return "\n".join(lines)
         case _:
@@ -36,20 +48,30 @@ def _cli_help(tool: str = "conda", limit: int = 0, offset: int = 0) -> str:
 
 def register_cli_help(mcp: FastMCP) -> None:
     @mcp.tool
-    async def cli_help(tool: str = "conda", limit: int = 0, offset: int = 0) -> str:
+    async def cli_help(
+        tool: str = "conda", limit: int = 0, offset: int = 0, grep: str = ""
+    ) -> str:
         """
         Provides the full help text for the given tool including all subcommands and options.
 
         To be used to answer advanced CLI questions beyond the knowledge cutoff of models,
         to e.g. help with new features that recently landed in the tool.
 
-        tool: str = "conda"
-        limit: max number of lines returned (0 means all)
-        offset: number of initial lines skipped
+        Args:
+            tool: str = "conda"
+            limit: max number of lines returned (0 means all)
+            offset: number of initial lines skipped
+            grep: Regular expression pattern to filter help lines (case-insensitive).
+                  Empty string returns all lines (default).
+                  Example: "install|update|create" returns lines matching any of these.
+                  Reduces context by ~90% for targeted queries.
+
         Returns:
-          A string with the help
+          A string with the help text
         """
         try:
-            return await asyncio.to_thread(_cli_help, tool, limit, offset)
+            return await asyncio.to_thread(_cli_help, tool, limit, offset, grep)
+        except ValueError as ve:
+            raise ToolError(f"[validation_error] Invalid input: {ve}") from ve
         except Exception as e:
-            raise ToolError(f"'cli_help' failed: {e}")
+            raise ToolError(f"[unknown_error] 'cli_help' failed: {e}") from e

--- a/conda_meta_mcp/tools/import_mapping.py
+++ b/conda_meta_mcp/tools/import_mapping.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastmcp.exceptions import ToolError
 
@@ -22,9 +22,15 @@ from conda_forge_metadata.autotick_bot.import_to_pkg import (
     map_import_to_package,
 )
 
+from .cache_utils import register_external_cache_clearer
+
 
 @lru_cache(maxsize=1024)
-def _map_import(import_name: str) -> dict:
+def _map_import(import_name: str, get_keys: str = "") -> dict[str, Any]:
+    """Map import name to package.
+
+    Returns dict with structure matching ImportMappingResult TypedDict.
+    """
     if not import_name or not import_name.strip():
         raise ValueError("import_name must be a non-empty string")
 
@@ -35,35 +41,44 @@ def _map_import(import_name: str) -> dict:
 
     if candidates is None or len(candidates) == 0:
         # No mapping known; identity fallback.
-        return {
+        result = {
             "query_import": query,
             "normalized_import": normalized,
             "best_package": normalized,
             "candidate_packages": [],
             "heuristic": "identity",
         }
-
-    best = map_import_to_package(query)
-
-    if best == normalized and best in candidates:
-        heuristic = "identity_present"
-    elif best in candidates:
-        heuristic = "ranked_selection"
     else:
-        heuristic = "fallback"
+        best = map_import_to_package(query)
 
-    return {
-        "query_import": query,
-        "normalized_import": normalized,
-        "best_package": best,
-        "candidate_packages": sorted(candidates),
-        "heuristic": heuristic,
-    }
+        if best == normalized and best in candidates:
+            heuristic = "identity_present"
+        elif best in candidates:
+            heuristic = "ranked_selection"
+        else:
+            heuristic = "fallback"
+
+        result = {
+            "query_import": query,
+            "normalized_import": normalized,
+            "best_package": best,
+            "candidate_packages": sorted(candidates),
+            "heuristic": heuristic,
+        }
+
+    # Apply field filtering if get_keys is specified
+    if get_keys and get_keys.strip():
+        keys = set(k.strip() for k in get_keys.split(",") if k.strip())
+        result = {k: v for k, v in result.items() if k in keys}
+
+    return result
 
 
 def register_import_mapping(mcp: FastMCP) -> None:
+    register_external_cache_clearer(_map_import.cache_clear)
+
     @mcp.tool
-    async def import_mapping(import_name: str) -> dict:
+    async def import_mapping(import_name: str, get_keys: str = "") -> dict[str, Any]:
         """
         Map a (possibly dotted) Python import name to the most likely conda package
         and expose supporting context.
@@ -80,21 +95,24 @@ def register_import_mapping(mcp: FastMCP) -> None:
           - ranked_selection:  Best package chosen via ranked hubs authorities ordering
           - fallback:          Best package not in candidates (unexpected edge case)
 
-        Returned dict schema:
-          {
-            "query_import":      original query string supplied by caller
-            "normalized_import": top-level portion used for lookup
-            "best_package":      chosen conda package name (may equal normalized_import)
-            "candidate_packages": sorted list of possible supplying packages (may be empty)
-            "heuristic":         one of the heuristic labels above
-          }
+        Returns:
+          dict with structure matching ImportMappingResult TypedDict:
+            - query_import: original query string supplied by caller
+            - normalized_import: top-level portion used for lookup
+            - best_package: chosen conda package name (may equal normalized_import)
+            - candidate_packages: sorted list of possible supplying packages (may be empty)
+            - heuristic: one of the heuristic labels above
 
         Args:
           import_name:
             Import string, e.g. "yaml", "matplotlib.pyplot", "sklearn.model_selection".
+          get_keys:
+            Comma-separated field names to include in results.
+            Empty string returns all fields (default).
+            Example: "best_package,heuristic" returns only key fields.
         """
         try:
-            return await asyncio.to_thread(_map_import, import_name)
+            return await asyncio.to_thread(_map_import, import_name, get_keys)
         except ValueError as ve:
             raise ToolError(f"'import_mapping' invalid input: {ve}") from ve
         except Exception as e:  # pragma: no cover - generic protection

--- a/conda_meta_mcp/tools/info.py
+++ b/conda_meta_mcp/tools/info.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastmcp import Context  # noqa: TC002
 from fastmcp.exceptions import ToolError
@@ -12,7 +12,13 @@ if TYPE_CHECKING:
 
 
 @cache
-def _get_info():
+def _get_info() -> dict[str, Any]:
+    """Get version information for all dependencies.
+
+    Returns:
+        dict[str, Any]: Mapping of package names to version strings.
+            See InfoResult TypedDict for structure.
+    """
     from conda import __version__ as conda_version
     from conda_package_streaming import __version__ as conda_package_streaming_version
     from fastmcp import __version__ as fastmcp_version
@@ -31,12 +37,20 @@ def _get_info():
 
 def register_info(mcp: FastMCP) -> None:
     @mcp.tool
-    async def info(ctx: Context) -> dict:
+    async def info(ctx: Context) -> dict[str, Any]:
         """
-        Display information about the MCP instance.
+        Display version information about the MCP instance.
+
+        Can be compared with local output of "conda info" to see if they match.
+
+        Returns:
+            dict[str, Any]: Version information for MCP instance and dependencies.
+                See InfoResult TypedDict for structure.
         """
         await ctx.info("Info got called")
         try:
             return await asyncio.to_thread(_get_info)
+        except ImportError as ie:
+            raise ToolError(f"[import_error] Failed to load dependencies: {ie}") from ie
         except Exception as e:
-            raise ToolError(f"'info' failed with: {e}")
+            raise ToolError(f"[unknown_error] 'info' failed: {e}") from e

--- a/conda_meta_mcp/tools/pkg_search.py
+++ b/conda_meta_mcp/tools/pkg_search.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ConfigDict
@@ -10,8 +11,11 @@ from pydantic import BaseModel, ConfigDict
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
+
 from conda.api import SubdirData
 from conda.models.version import VersionOrder
+
+from .cache_utils import register_external_cache_clearer
 
 
 class PackageRecord(BaseModel):
@@ -36,7 +40,7 @@ class PackageRecord(BaseModel):
         return self._ordering_tuple() < other._ordering_tuple()
 
 
-@lru_cache(maxsize=1000)
+@lru_cache(maxsize=32)
 def _full_package_search(package_ref_or_match_spec, channel, platform) -> list[PackageRecord]:
     return list(
         sorted(
@@ -59,17 +63,76 @@ def _full_package_search(package_ref_or_match_spec, channel, platform) -> list[P
     )
 
 
+def _clear_conda_subdirdata_cache_for_pkg_search() -> None:
+    """
+    Clear Conda's SubdirData global caches used by package_search.
+
+    This cleans up large repodata JSON caches held in memory by Conda,
+    in addition to our own lru_cache for _full_package_search.
+    """
+    with contextlib.suppress(Exception):
+        from conda.core.subdir_data import SubdirData
+
+        cache_attr = "_cache_"
+        if hasattr(SubdirData, cache_attr):
+            cache_obj = getattr(SubdirData, cache_attr, None)
+            if hasattr(cache_obj, "clear") and callable(cache_obj.clear):
+                cache_obj.clear()
+
+        if hasattr(SubdirData, "clear_cached_local_channel_data"):
+            SubdirData.clear_cached_local_channel_data()
+
+
+def _filter_keys(results: list[PackageRecord], get_keys: str) -> list[dict]:
+    """Filter PackageRecord results to specified keys only.
+
+    Args:
+        results: List of PackageRecord objects
+        get_keys: Comma-separated field names to include (empty = all fields)
+
+    Returns:
+        List of dictionaries with only requested keys, or original records if get_keys is empty
+    """
+    if not get_keys or not get_keys.strip():
+        # Return as dict to maintain serialization
+        return [r.model_dump() for r in results]
+
+    keys = set(k.strip() for k in get_keys.split(",") if k.strip())
+    return [{k: v for k, v in r.model_dump().items() if k in keys} for r in results]
+
+
 def _package_search(
-    package_ref_or_match_spec, channel, platform, limit, offset
-) -> list[PackageRecord]:
+    package_ref_or_match_spec, channel, platform, limit, offset, get_keys: str = ""
+) -> dict[str, Any]:
+    """Search for packages and return results with pagination metadata.
+
+    Returns dict with structure matching PackageSearchResult TypedDict:
+    {
+        'results': list of package records (filtered by get_keys if specified),
+        'total': total number of matching packages,
+        'limit': limit used in this query,
+        'offset': offset used in this query
+    }
+    """
     results = _full_package_search(package_ref_or_match_spec, channel, platform)
     offset = max(offset or 0, 0)
-    if limit and limit > 0:
-        return results[offset : offset + limit]
-    return results[offset:]
+    paginated = results[offset : offset + limit] if limit and limit > 0 else results[offset:]
+
+    # Apply field filtering if get_keys is specified
+    filtered = _filter_keys(paginated, get_keys)
+
+    return {
+        "results": filtered,
+        "total": len(results),
+        "limit": limit if limit and limit > 0 else len(results),
+        "offset": offset,
+    }
 
 
 def register_package_search(mcp: FastMCP) -> None:
+    register_external_cache_clearer(_full_package_search.cache_clear)
+    register_external_cache_clearer(_clear_conda_subdirdata_cache_for_pkg_search)
+
     @mcp.tool
     async def package_search(
         package_ref_or_match_spec: str,
@@ -77,7 +140,8 @@ def register_package_search(mcp: FastMCP) -> None:
         platform: str,
         limit: int = 0,
         offset: int = 0,
-    ) -> list[PackageRecord]:
+        get_keys: str = "",
+    ) -> dict[str, Any]:
         """
         Search available conda packages matching the given package_ref_or_match_spec, channel, and
         platform.
@@ -87,6 +151,7 @@ def register_package_search(mcp: FastMCP) -> None:
           - Ordered by newest (version, then build_number descending).
           - limit=1 reliably returns the single newest record.
           - Supports paging via (offset, limit).
+          - Optional field filtering via get_keys parameter.
 
         Args:
           package_ref_or_match_spec (PackageRef or MatchSpec or str):
@@ -95,10 +160,28 @@ def register_package_search(mcp: FastMCP) -> None:
           platform (str): e.g. "linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"
           limit (int): Maximum number of results to return (0 means all).
           offset (int): Number of results to skip before applying limit (for paging).
+          get_keys (str): Comma-separated field names to include in results.
+                         Empty string returns all fields (default).
+                         Example: "version,build,url" reduces context by ~60-70%.
+
+        Returns:
+          dict with keys:
+            - results: list of package records (filtered by get_keys if specified)
+            - total: total number of matching packages
+            - limit: limit used in this query
+            - offset: offset used in this query
         """
         try:
             return await asyncio.to_thread(
-                _package_search, package_ref_or_match_spec, channel, platform, limit, offset
+                _package_search,
+                package_ref_or_match_spec,
+                channel,
+                platform,
+                limit,
+                offset,
+                get_keys,
             )
+        except ValueError as ve:
+            raise ToolError(f"[validation_error] Invalid input: {ve}") from ve
         except Exception as e:
-            raise ToolError(f"'package_search' failed with: {e}")
+            raise ToolError(f"[unknown_error] 'package_search' failed: {e}") from e

--- a/pixi.lock
+++ b/pixi.lock
@@ -496,6 +496,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/py-key-value-aio-0.2.8-pyh966e15f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/py-key-value-shared-0.2.8-pyhcf101f3_0.conda
@@ -694,6 +695,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py313h9734d34_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/py-key-value-aio-0.2.8-pyh966e15f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/py-key-value-shared-0.2.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-rattler-0.15.0-py310h96aa460_1.conda
@@ -1252,8 +1254,8 @@ packages:
   timestamp: 1764081424684
 - pypi: ./
   name: conda-meta-mcp
-  version: 0.1.dev1+g63f771846
-  sha256: e9ca2a0998ae74cdd0315ad8fb8e3e93726dbcd11bbbd54af98fca46e6122f68
+  version: 0.1.dev76+g197f66a25
+  sha256: 0a166b76e066ebc51213cae3e444312ec8263020c6a2f921469eef06ee48cb46
   requires_dist:
   - fastmcp
   requires_python: '>=3.13'
@@ -3296,6 +3298,34 @@ packages:
   - pkg:pypi/pre-commit?source=hash-mapping
   size: 201265
   timestamp: 1764067809524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py313h54dd161_0.conda
+  sha256: 26cf5a69d04ef66f03516b8a8211a43bb23d5225faacd7d36e5c987b0d66af0a
+  md5: 1d719fc61f91ab2644a2eeb35fcab360
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 501735
+  timestamp: 1762092897061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.1.3-py313h9734d34_0.conda
+  sha256: a175fee131b28ecd2dadd2b3fdc9b75b50ad5ad502d984280ae064152739c567
+  md5: b17da028e6650dce95f8247faf84ba48
+  depends:
+  - python
+  - python 3.13.* *_cp313
+  - __osx >=11.0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 515398
+  timestamp: 1762093071645
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ conda-forge-metadata = "*"
 conda-package-streaming = ">=0.12.0"
 fastmcp = ">=2.11.3"
 libmambapy = ">=2.3.1"
+pyyaml = ">=5.1"
 
 [tool.pixi.environments]
 dev = ["test"]
@@ -49,6 +50,7 @@ dev = ["test"]
 [tool.pixi.feature.test.dependencies]
 pixi-diff-to-markdown = "*"
 pre-commit = "*"
+psutil = "*"
 pytest = "*"
 pytest-asyncio = "*"
 pytest-cov = ">=7,<8"

--- a/server-info.json
+++ b/server-info.json
@@ -15,7 +15,7 @@
     {
       "name": "cli_help",
       "title": null,
-      "description": "Provides the full help text for the given tool including all subcommands and options.\n\nTo be used to answer advanced CLI questions beyond the knowledge cutoff of models,\nto e.g. help with new features that recently landed in the tool.\n\ntool: str = \"conda\"\nlimit: max number of lines returned (0 means all)\noffset: number of initial lines skipped\nReturns:\n  A string with the help",
+      "description": "Provides the full help text for the given tool including all subcommands and options.\n\nTo be used to answer advanced CLI questions beyond the knowledge cutoff of models,\nto e.g. help with new features that recently landed in the tool.\n\nArgs:\n    tool: str = \"conda\"\n    limit: max number of lines returned (0 means all)\n    offset: number of initial lines skipped\n    grep: Regular expression pattern to filter help lines (case-insensitive).\n          Empty string returns all lines (default).\n          Example: \"install|update|create\" returns lines matching any of these.\n          Reduces context by ~90% for targeted queries.\n\nReturns:\n  A string with the help text",
       "inputSchema": {
         "properties": {
           "tool": {
@@ -29,6 +29,10 @@
           "offset": {
             "default": 0,
             "type": "integer"
+          },
+          "grep": {
+            "default": "",
+            "type": "string"
           }
         },
         "type": "object"
@@ -56,7 +60,7 @@
     {
       "name": "info",
       "title": null,
-      "description": "Display information about the MCP instance.",
+      "description": "Display version information about the MCP instance.\n\nCan be compared with local output of \"conda info\" to see if they match.\n\nReturns:\n    dict[str, Any]: Version information for MCP instance and dependencies.\n        See InfoResult TypedDict for structure.",
       "inputSchema": {
         "properties": {},
         "type": "object"
@@ -76,7 +80,7 @@
     {
       "name": "package_insights",
       "title": null,
-      "description": "Provides insights into a package's info tarball\n\nThat includes the rendered recipe (meta.yaml) that allows for easy inspection of the\npackage's build process, e.g. see build, host and run time dependencies. Which have\nbig influence on what packages are linked against. The run_exports which end up as\nrun time dependencies for other packages linked against this package. And the about\ninformation which contain the remote_url and sha to the repo location where the\npackage recipe is maintained. That helps to open PRs in the right location to fix\nissues with the recipe.\n\nArgs:\n  url: The full package URL, e.g.\n  \"https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py311h7f8727e_0.tar.bz2\"\n\n  file: can be set to \"some\", \"all\", \"list-without-content\" or a specific filename\n  limit: max number of lines returned per file (0 means all; ignored for\n    list-without-content)\n  offset: number of initial lines skipped per file (ignored for\n    list-without-content)\n  Returns:\n    A dictionary with key=filename, value=content.",
+      "description": "Provides insights into a package's info tarball\n\nThat includes the rendered recipe (meta.yaml) that allows for easy inspection of the\npackage's build process, e.g. see build, host and run time dependencies. Which have\nbig influence on what packages are linked against. The run_exports which end up as\nrun time dependencies for other packages linked against this package. And the about\ninformation which contain the remote_url and sha to the repo location where the\npackage recipe is maintained. That helps to open PRs in the right location to fix\nissues with the recipe.\n\nArgs:\n  url: The full package URL, e.g.\n  \"https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py311h7f8727e_0.tar.bz2\"\n\n  file: can be set to \"some\", \"all\", \"list-without-content\" or a specific filename\n  limit: max number of lines returned per file (0 means all; ignored for\n    list-without-content)\n  offset: number of initial lines skipped per file (ignored for\n    list-without-content)\n   get_keys: Comma-separated keys to extract from parsed file content (YAML/JSON).\n            Empty string returns full file content (default).\n            Example: \"channels,conda_build_version\" extracts those fields from\n            about.json. Requires exactly one file (use 'file' parameter).\n            Significantly reduces context by returning only needed fields.\n   Returns:\n     A dictionary with key=filename, value=content or parsed object.",
       "inputSchema": {
         "properties": {
           "url": {
@@ -93,6 +97,10 @@
           "offset": {
             "default": 0,
             "type": "integer"
+          },
+          "get_keys": {
+            "default": "",
+            "type": "string"
           }
         },
         "required": [
@@ -101,9 +109,7 @@
         "type": "object"
       },
       "outputSchema": {
-        "additionalProperties": {
-          "type": "string"
-        },
+        "additionalProperties": true,
         "type": "object"
       },
       "icons": null,
@@ -117,7 +123,7 @@
     {
       "name": "package_search",
       "title": null,
-      "description": "Search available conda packages matching the given package_ref_or_match_spec, channel, and\nplatform.\n\nFeatures:\n  - Results are deduplicated.\n  - Ordered by newest (version, then build_number descending).\n  - limit=1 reliably returns the single newest record.\n  - Supports paging via (offset, limit).\n\nArgs:\n  package_ref_or_match_spec (PackageRef or MatchSpec or str):\n    e.g. \"numpy\", \"numpy>=1.20\", \"numpy=1.20.3\", \"numpy=1.20.3=py38h550f1ac_0\"\n  channel (str): e.g. \"defaults\", \"conda-forge\", \"bioconda\", \"nvidia\"\n  platform (str): e.g. \"linux-64\", \"linux-aarch64\", \"osx-64\", \"osx-arm64\", \"win-64\"\n  limit (int): Maximum number of results to return (0 means all).\n  offset (int): Number of results to skip before applying limit (for paging).",
+      "description": "Search available conda packages matching the given package_ref_or_match_spec, channel, and\nplatform.\n\nFeatures:\n  - Results are deduplicated.\n  - Ordered by newest (version, then build_number descending).\n  - limit=1 reliably returns the single newest record.\n  - Supports paging via (offset, limit).\n  - Optional field filtering via get_keys parameter.\n\nArgs:\n  package_ref_or_match_spec (PackageRef or MatchSpec or str):\n    e.g. \"numpy\", \"numpy>=1.20\", \"numpy=1.20.3\", \"numpy=1.20.3=py38h550f1ac_0\"\n  channel (str): e.g. \"defaults\", \"conda-forge\", \"bioconda\", \"nvidia\"\n  platform (str): e.g. \"linux-64\", \"linux-aarch64\", \"osx-64\", \"osx-arm64\", \"win-64\"\n  limit (int): Maximum number of results to return (0 means all).\n  offset (int): Number of results to skip before applying limit (for paging).\n  get_keys (str): Comma-separated field names to include in results.\n                 Empty string returns all fields (default).\n                 Example: \"version,build,url\" reduces context by ~60-70%.\n\nReturns:\n  dict with keys:\n    - results: list of package records (filtered by get_keys if specified)\n    - total: total number of matching packages\n    - limit: limit used in this query\n    - offset: offset used in this query",
       "inputSchema": {
         "properties": {
           "package_ref_or_match_spec": {
@@ -136,6 +142,10 @@
           "offset": {
             "default": 0,
             "type": "integer"
+          },
+          "get_keys": {
+            "default": "",
+            "type": "string"
           }
         },
         "required": [
@@ -146,48 +156,8 @@
         "type": "object"
       },
       "outputSchema": {
-        "$defs": {
-          "PackageRecord": {
-            "properties": {
-              "version": {
-                "type": "string"
-              },
-              "build_number": {
-                "type": "string"
-              },
-              "build": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              },
-              "depends": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "version",
-              "build_number",
-              "build",
-              "url",
-              "depends"
-            ],
-            "type": "object"
-          }
-        },
-        "properties": {
-          "result": {
-            "items": {
-              "$ref": "#/$defs/PackageRecord"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "result"
-        ],
-        "type": "object",
-        "x-fastmcp-wrap-result": true
+        "additionalProperties": true,
+        "type": "object"
       },
       "icons": null,
       "annotations": null,
@@ -200,7 +170,7 @@
     {
       "name": "repoquery",
       "title": null,
-      "description": "Run a conda repoquery (depends | whoneeds) for a single spec\nand channel. Installed packages excluded. Supports pagination via offset/limit.\n- depends/whoneeds: raw structure unpaginated; sliced pkgs list with offset/limit/total\n  when paginated\n\nArgs:\n    subcmd (str): e.g. \"depends\": show dependencies of this package,\n                       \"whoneeds\": show packages that depend on this package.\n    channel (str): e.g. \"defaults\", \"conda-forge\", \"bioconda\", \"nvidia\"\n    platform (str): e.g. \"linux-64\", \"linux-aarch64\", \"osx-64\", \"osx-arm64\", \"win-64\"\n    limit (int): for pagination / slicing\n    offset (int): for pagination / slicing",
+      "description": "Run a conda repoquery (depends | whoneeds) for a single spec\nand channel. Installed packages excluded. Supports pagination via offset/limit.\n- depends/whoneeds: raw structure unpaginated; sliced pkgs list with offset/limit/total\n  when paginated\n\nArgs:\n    subcmd (str): e.g. \"depends\": show dependencies of this package,\n                       \"whoneeds\": show packages that depend on this package.\n    channel (str): e.g. \"defaults\", \"conda-forge\", \"bioconda\", \"nvidia\"\n    platform (str): e.g. \"linux-64\", \"linux-aarch64\", \"osx-64\", \"osx-arm64\", \"win-64\"\n    limit (int): for pagination / slicing\n    offset (int): for pagination / slicing\n    get_keys (str): Comma-separated field names to include in results.\n                   Empty string returns all fields (default).\n                   Example: \"name,version,url,license\" reduces context by ~60-80%.",
       "inputSchema": {
         "properties": {
           "subcmd": {
@@ -227,6 +197,10 @@
           "limit": {
             "default": 30,
             "type": "integer"
+          },
+          "get_keys": {
+            "default": "",
+            "type": "string"
           }
         },
         "required": [
@@ -251,10 +225,14 @@
     {
       "name": "import_mapping",
       "title": null,
-      "description": "Map a (possibly dotted) Python import name to the most likely conda package\nand expose supporting context.\n\nWhat this does:\n  - Normalizes the import to its top-level module (e.g. \"numpy.linalg\" -> \"numpy\")\n  - Retrieves an approximate candidate set of conda packages that may provide it\n  - Applies a heuristic to pick a single \"best\" package\n  - Returns a structured result with the decision rationale\n\nHeuristic labels:\n  - identity:          No candidates known; fallback to normalized import\n  - identity_present:  Candidates exist AND the normalized import name is among them\n  - ranked_selection:  Best package chosen via ranked hubs authorities ordering\n  - fallback:          Best package not in candidates (unexpected edge case)\n\nReturned dict schema:\n  {\n    \"query_import\":      original query string supplied by caller\n    \"normalized_import\": top-level portion used for lookup\n    \"best_package\":      chosen conda package name (may equal normalized_import)\n    \"candidate_packages\": sorted list of possible supplying packages (may be empty)\n    \"heuristic\":         one of the heuristic labels above\n  }\n\nArgs:\n  import_name:\n    Import string, e.g. \"yaml\", \"matplotlib.pyplot\", \"sklearn.model_selection\".",
+      "description": "Map a (possibly dotted) Python import name to the most likely conda package\nand expose supporting context.\n\nWhat this does:\n  - Normalizes the import to its top-level module (e.g. \"numpy.linalg\" -> \"numpy\")\n  - Retrieves an approximate candidate set of conda packages that may provide it\n  - Applies a heuristic to pick a single \"best\" package\n  - Returns a structured result with the decision rationale\n\nHeuristic labels:\n  - identity:          No candidates known; fallback to normalized import\n  - identity_present:  Candidates exist AND the normalized import name is among them\n  - ranked_selection:  Best package chosen via ranked hubs authorities ordering\n  - fallback:          Best package not in candidates (unexpected edge case)\n\nReturns:\n  dict with structure matching ImportMappingResult TypedDict:\n    - query_import: original query string supplied by caller\n    - normalized_import: top-level portion used for lookup\n    - best_package: chosen conda package name (may equal normalized_import)\n    - candidate_packages: sorted list of possible supplying packages (may be empty)\n    - heuristic: one of the heuristic labels above\n\nArgs:\n  import_name:\n    Import string, e.g. \"yaml\", \"matplotlib.pyplot\", \"sklearn.model_selection\".\n  get_keys:\n    Comma-separated field names to include in results.\n    Empty string returns all fields (default).\n    Example: \"best_package,heuristic\" returns only key fields.",
       "inputSchema": {
         "properties": {
           "import_name": {
+            "type": "string"
+          },
+          "get_keys": {
+            "default": "",
             "type": "string"
           }
         },
@@ -278,7 +256,7 @@
     {
       "name": "pypi_to_conda",
       "title": null,
-      "description": "Map a (case-sensitive) PyPI distribution name to the most likely conda package name.\n\nReturns:\n  {\n    \"pypi_name\": original input (trimmed),\n    \"conda_name\": mapped (lowercase) conda name (fallback: pypi_name.lower()),\n    \"changed\": conda_name != pypi_name.lower()\n  }\n\n'changed' is True only when the resolved conda name differs from simple lowercase.",
+      "description": "Map a (case-sensitive) PyPI distribution name to the most likely conda package name.\n\nReturns:\n  dict with structure matching PyPiToCondaResult TypedDict:\n    - pypi_name: original input (trimmed)\n    - conda_name: mapped (lowercase) conda name (fallback: pypi_name.lower())\n    - changed: conda_name != pypi_name.lower()\n\n'changed' is True only when the resolved conda name differs from simple lowercase.",
       "inputSchema": {
         "properties": {
           "pypi_name": {
@@ -293,6 +271,34 @@
       "outputSchema": {
         "additionalProperties": true,
         "type": "object"
+      },
+      "icons": null,
+      "annotations": null,
+      "_meta": {
+        "_fastmcp": {
+          "tags": []
+        }
+      }
+    },
+    {
+      "name": "cache_maintenance",
+      "title": null,
+      "description": "Run cache maintenance for all registered external and tool-level caches.\n\nReturns a short status message after cleanup has been triggered.",
+      "inputSchema": {
+        "properties": {},
+        "type": "object"
+      },
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
       },
       "icons": null,
       "annotations": null,

--- a/tests/tools/test_cache_utils.py
+++ b/tests/tools/test_cache_utils.py
@@ -1,0 +1,80 @@
+import asyncio
+import time
+from typing import Any
+
+import psutil
+import pytest
+
+from conda_meta_mcp.server import setup_server
+
+
+def _current_rss_mb() -> float:
+    """Return current process RSS in megabytes."""
+    process = psutil.Process()
+    return process.memory_info().rss / (1024 * 1024)
+
+
+async def _hammer_tools(client: Any, iterations: int = 2) -> None:
+    """Call memory-heavy tools repeatedly to exercise caches."""
+    for _ in range(iterations):
+        # package_search: hits SubdirData and _full_package_search cache
+        await client.call_tool(
+            "package_search",
+            {
+                "package_ref_or_match_spec": "numpy",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "limit": 50,
+                "get_keys": "",
+            },
+        )
+
+        # repoquery: uses libmamba and _cached_raw_query cache
+        await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "tree": True,
+                "offset": 0,
+                "limit": 100,
+                "get_keys": "",
+            },
+        )
+
+        # pypi_to_conda: exercises _map_pypi_name cache
+        await client.call_tool(
+            "pypi_to_conda",
+            {
+                "pypi_name": "numpy",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_cache_maintenance__called__memory_freed() -> None:
+    from fastmcp.client import Client  # type: ignore[import-not-found]
+
+    server = setup_server(log_level="INFO")
+
+    async with Client(server) as client:
+        baseline = _current_rss_mb()
+
+        await _hammer_tools(client, iterations=2)
+        after_load = _current_rss_mb()
+
+        await client.call_tool("cache_maintenance", {})
+
+        await asyncio.sleep(0.5)
+        import gc
+
+        gc.collect()
+        time.sleep(0.5)
+
+        after_cleanup = _current_rss_mb()
+
+        assert after_load >= baseline
+        assert after_cleanup <= after_load
+        assert after_load - after_cleanup >= 128

--- a/tests/tools/test_cli_help.py
+++ b/tests/tools/test_cli_help.py
@@ -18,3 +18,157 @@ async def test_cli_help__unknown_tool_error(server):
     with pytest.raises(ToolError):
         async with Client(server) as client:
             await client.call_tool("cli_help", {"tool": "unknown_tool_xyz"})
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_empty_returns_all(server):
+    """Empty grep should return all lines (backward compatible)."""
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "",  # Empty = all lines
+            },
+        )
+        data = result.data
+        lines = data.strip().split("\n")
+        # Full help should have 1000+ lines
+        assert len(lines) > 1000
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_filters_lines(server):
+    """grep parameter should filter to only matching lines."""
+    async with Client(server) as client:
+        # Search for install-related commands
+        result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "install",
+            },
+        )
+        data = result.data
+        lines = [line for line in data.strip().split("\n") if line.strip()]
+
+        # All non-empty lines should contain "install" (case-insensitive)
+        for line in lines:
+            assert "install" in line.lower()
+
+        # Should be much fewer lines than full help
+        assert len(lines) < 100  # Full help > 1000, grep results < 100
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_context_reduction(server):
+    """grep should reduce context usage by ~90% for targeted queries."""
+    async with Client(server) as client:
+        # Get full help
+        full_result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "",
+            },
+        )
+        full_size = len(full_result.data)
+
+        # Get filtered help
+        filtered_result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "install|update|create",
+            },
+        )
+        filtered_size = len(filtered_result.data)
+
+        # Should be significantly smaller (~90% or more)
+        reduction = (full_size - filtered_size) / full_size
+        assert reduction > 0.85  # At least 85% reduction (typically 90%+)
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_case_insensitive(server):
+    """grep should be case-insensitive."""
+    async with Client(server) as client:
+        # Search lowercase
+        result_lower = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "install",
+            },
+        )
+        lower_lines = len([line for line in result_lower.data.split("\n") if line.strip()])
+
+        # Search uppercase
+        result_upper = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "INSTALL",
+            },
+        )
+        upper_lines = len([line for line in result_upper.data.split("\n") if line.strip()])
+
+        # Should return same number of results (case-insensitive)
+        assert lower_lines == upper_lines
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_regex_patterns(server):
+    """grep should support regex patterns."""
+    async with Client(server) as client:
+        # Use regex alternation for common conda subcommands
+        result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                "grep": "create|install|list",  # Lines containing create, install, or list
+            },
+        )
+        data = result.data
+        lines = [line for line in data.strip().split("\n") if line.strip()]
+
+        # Should have some matching lines
+        assert len(lines) > 0
+
+        # Each line should match the pattern (case-insensitive)
+        import re
+
+        pattern = re.compile("create|install|list", re.IGNORECASE)
+        for line in lines:
+            assert pattern.search(line)
+
+
+@pytest.mark.asyncio
+async def test_cli_help__grep_invalid_regex_error(server):
+    """grep with invalid regex should raise error."""
+    with pytest.raises(ToolError):
+        async with Client(server) as client:
+            await client.call_tool(
+                "cli_help",
+                {
+                    "tool": "conda",
+                    "grep": "[invalid(regex",  # Invalid regex syntax
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_cli_help__backward_compat_no_grep_param(server):
+    """Old cli_help calls without grep should still work."""
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "cli_help",
+            {
+                "tool": "conda",
+                # No grep parameter
+            },
+        )
+        data = result.data
+        lines = data.strip().split("\n")
+        # Should return all lines
+        assert len(lines) > 1000

--- a/tests/tools/test_repoquery.py
+++ b/tests/tools/test_repoquery.py
@@ -142,3 +142,116 @@ async def test_repoquery_error_invalid_subcmd(server):
                     "platform": "osx-arm64",
                 },
             )
+
+
+@pytest.mark.asyncio
+async def test_repoquery__get_keys_empty_returns_all(server):
+    """Empty get_keys should return all package fields (backward compatible)."""
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "limit": 1,
+                "offset": 0,
+                "get_keys": "",  # Empty = all fields
+            },
+        )
+        data = result.data
+        # Should have 20+ fields per package
+        inner = data.get("result", {})
+        packages = inner.get("pkgs") or inner.get("result", {}).get("pkgs", [])
+        assert len(packages) > 0
+        first_pkg = packages[0]
+        # Verify we have many fields
+        assert len(first_pkg.keys()) >= 15
+
+
+@pytest.mark.asyncio
+async def test_repoquery__get_keys_filters_packages(server):
+    """get_keys parameter should filter packages to only requested fields."""
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "limit": 2,
+                "offset": 0,
+                "get_keys": "name,version,url",  # Only these 3 fields
+            },
+        )
+        data = result.data
+        inner = data.get("result", {})
+        packages = inner.get("pkgs") or inner.get("result", {}).get("pkgs", [])
+
+        # All packages should have ONLY requested fields
+        for pkg in packages:
+            assert set(pkg.keys()) == {"name", "version", "url"}
+            assert "build" not in pkg
+            assert "depends" not in pkg
+
+
+@pytest.mark.asyncio
+async def test_repoquery__get_keys_context_reduction(server):
+    """get_keys should reduce repoquery result size by 60-80%."""
+    async with Client(server) as client:
+        # Get full result
+        full_result = await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "limit": 5,
+                "offset": 0,
+                "get_keys": "",
+            },
+        )
+        full_size = len(str(full_result.data))
+
+        # Get filtered result
+        filtered_result = await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "platform": "osx-arm64",
+                "limit": 5,
+                "offset": 0,
+                "get_keys": "name,version",
+            },
+        )
+        filtered_size = len(str(filtered_result.data))
+
+        # Filtered should be significantly smaller (60-80% reduction)
+        reduction = (full_size - filtered_size) / full_size
+        assert reduction > 0.6  # At least 60% reduction
+
+
+@pytest.mark.asyncio
+async def test_repoquery__backward_compat_no_get_keys_param(server):
+    """Old repoquery calls without get_keys should still work."""
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "repoquery",
+            {
+                "subcmd": "depends",
+                "spec": "python",
+                "channel": "conda-forge",
+                "limit": 1,
+                # No get_keys parameter
+            },
+        )
+        data = result.data
+        inner = data.get("result", {})
+        packages = inner.get("pkgs") or inner.get("result", {}).get("pkgs", [])
+        # Should return all fields by default
+        assert len(packages[0].keys()) >= 15


### PR DESCRIPTION
## Summary
- **Add `get_keys` parameter** to field filtering in pkg_search, repoquery, pkg_insights, and import_mapping tools. Reduces context by 60-80% by allowing users to request only specific fields instead of complete records.
- **Add `grep` parameter** to cli_help for pattern-based line filtering. Reduces context by ~90% for targeted CLI documentation queries.
- **Maintain backward compatibility**: empty `get_keys` or `grep` parameters return all data (previous behavior), so existing code continues to work unchanged.