### PR TITLE
migrate file path search url

### DIFF
--- a/conda_meta_mcp/tools/file_path_search.py
+++ b/conda_meta_mcp/tools/file_path_search.py
@@ -24,7 +24,7 @@ def _file_path_search_raw(path):
 
     try:
         r = requests.get(
-            "https://cforge.quansight.dev/path_to_artifacts/find_artifacts.json",
+            "https://conda-db.openteams.ai/path_to_artifacts/find_artifacts.json",
             params={"path": query},
             timeout=10,
         )

--- a/tests/tools/test_file_path_search.py
+++ b/tests/tools/test_file_path_search.py
@@ -4,10 +4,6 @@ from fastmcp.exceptions import ToolError
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="Temporarily allow failure: depends on external cforge.quansight.dev API availability",
-    strict=False,
-)
 async def test_file_path_search__success(server):
     async with Client(server) as client:
         result = await client.call_tool(
@@ -34,10 +30,6 @@ async def test_file_path_search__success(server):
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="Temporarily allow failure: depends on external cforge.quansight.dev API availability",
-    strict=False,
-)
 async def test_file_path_search__pagination(server):
     async with Client(server) as client:
         r0 = await client.call_tool(


### PR DESCRIPTION
The VM hosting cforge.quansight.dev was [decommissioned on 2026-03-13](Quansight-Labs/conda-metadata-app#62). The same datasette service is now at https://conda-db.openteams.ai. See: Quansight-Labs/conda-metadata-app#66.
Also removes the xfail markers on the integration tests since the new endpoint is stable.