### PR TITLE
fix(server): exit when MCP parent process disappears

### DIFF
--- a/conda_meta_mcp/server.py
+++ b/conda_meta_mcp/server.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ctypes
 import importlib
 import os
 import sys
+import threading
+import time
 from typing import TYPE_CHECKING
 
 from fastmcp import FastMCP
@@ -13,8 +16,88 @@ if TYPE_CHECKING:
     import argparse
 
 SERVICE_NAME = "Conda ECO System Meta Data MCP"
+_PARENT_WATCHDOG_ENV = "CONDA_META_MCP_PARENT_WATCHDOG"
+_PARENT_PID_ENV = "CONDA_META_MCP_PARENT_PID"
 
 _periodic_cleanup_task: asyncio.Task | None = None
+
+
+def _env_enabled(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _parent_pid() -> int:
+    configured_pid = os.getenv(_PARENT_PID_ENV)
+    if configured_pid:
+        with contextlib.suppress(ValueError):
+            return int(configured_pid)
+    return os.getppid()
+
+
+def _wait_for_process_exit_windows(pid: int) -> bool:
+    """Wait for the recorded Windows parent process to exit."""
+    win_dll = getattr(ctypes, "WinDLL", None)
+    if win_dll is None:  # pragma: no cover - defensive for non-Windows tests
+        return False
+
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32)
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.WaitForSingleObject.argtypes = (ctypes.c_void_p, ctypes.c_uint32)
+    kernel32.WaitForSingleObject.restype = ctypes.c_uint32
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+
+    handle = kernel32.OpenProcess(0x00100000, False, pid)  # SYNCHRONIZE
+    if not handle:
+        return True
+
+    try:
+        wait_result = kernel32.WaitForSingleObject(handle, 0xFFFFFFFF)  # INFINITE
+    finally:
+        kernel32.CloseHandle(handle)
+
+    return wait_result == 0  # WAIT_OBJECT_0
+
+
+def _wait_for_parent_exit(pid: int) -> bool:
+    if os.name == "nt":
+        return _wait_for_process_exit_windows(pid)
+
+    while os.getppid() == pid:
+        time.sleep(1)
+    return True
+
+
+def _exit_process(code: int) -> None:
+    os._exit(code)
+
+
+def _parent_watchdog_worker(
+    pid: int,
+    wait_for_process_exit=_wait_for_parent_exit,
+    exit_process=_exit_process,
+) -> None:
+    if wait_for_process_exit(pid):
+        exit_process(0)
+
+
+def _start_parent_watchdog() -> threading.Thread | None:
+    """Stop orphaned servers when MCP hosts or proxy parents disappear."""
+    if not _env_enabled(_PARENT_WATCHDOG_ENV, default=True):
+        return None
+
+    thread = threading.Thread(
+        target=_parent_watchdog_worker,
+        args=(_parent_pid(),),
+        name="conda-meta-mcp-parent-watchdog",
+        daemon=True,
+    )
+    thread.start()
+    return thread
 
 
 def _build_code_mode_transform():
@@ -51,6 +134,7 @@ def setup_run(subparser: argparse._SubParsersAction):
 def run_cmd(args):
     log_level = "DEBUG" if args.verbose else "INFO"
     os.environ["FASTMCP_LOG_LEVEL"] = log_level
+    _start_parent_watchdog()
     mcp = setup_server(args.code)
 
     run_kwargs = {"transport": args.transport, "show_banner": False}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -81,6 +81,115 @@ def test_build_code_mode_transform__configured(monkeypatch):
     }
 
 
+def test_parent_watchdog_worker__exits_after_parent_exit():
+    calls = {}
+
+    def wait_for_process_exit(pid):
+        calls["pid"] = pid
+        return True
+
+    def exit_process(code):
+        calls["exit_code"] = code
+
+    server._parent_watchdog_worker(123, wait_for_process_exit, exit_process)
+
+    assert calls == {"pid": 123, "exit_code": 0}
+
+
+def test_parent_watchdog_worker__does_not_exit_if_parent_wait_unavailable():
+    calls = {}
+
+    def wait_for_process_exit(pid):
+        calls["pid"] = pid
+        return False
+
+    def exit_process(code):
+        calls["exit_code"] = code
+
+    server._parent_watchdog_worker(123, wait_for_process_exit, exit_process)
+
+    assert calls == {"pid": 123}
+
+
+def test_wait_for_parent_exit__returns_after_parent_changes(monkeypatch):
+    parent_pids = iter([123, 1])
+
+    monkeypatch.setattr(server.os, "name", "posix")
+    monkeypatch.setattr(server.os, "getppid", lambda: next(parent_pids))
+    monkeypatch.setattr(server.time, "sleep", lambda seconds: None)
+
+    assert server._wait_for_parent_exit(123) is True
+
+
+def test_start_parent_watchdog__starts(monkeypatch):
+    calls = {}
+
+    class FakeThread:
+        def __init__(self, *, target, args, name, daemon):
+            calls["target"] = target
+            calls["args"] = args
+            calls["name"] = name
+            calls["daemon"] = daemon
+
+        def start(self):
+            calls["started"] = True
+
+    monkeypatch.setattr(server, "_parent_pid", lambda: 123)
+    monkeypatch.setattr(server.threading, "Thread", FakeThread)
+
+    thread = server._start_parent_watchdog()
+
+    assert isinstance(thread, FakeThread)
+    assert calls == {
+        "target": server._parent_watchdog_worker,
+        "args": (123,),
+        "name": "conda-meta-mcp-parent-watchdog",
+        "daemon": True,
+        "started": True,
+    }
+
+
+def test_start_parent_watchdog__skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("CONDA_META_MCP_PARENT_WATCHDOG", "0")
+
+    assert server._start_parent_watchdog() is None
+
+
+def test_run_cmd__starts_parent_watchdog_before_setup(monkeypatch):
+    calls = {}
+    order = []
+
+    class Dummy:
+        def run(self, **kw):
+            calls["kw"] = kw
+
+    def fake_start_watchdog():
+        order.append("watchdog")
+
+    def fake_setup_server(code=False):
+        order.append("setup")
+        return Dummy()
+
+    monkeypatch.setattr(server, "setup_server", fake_setup_server)
+    monkeypatch.setattr(server, "_start_parent_watchdog", fake_start_watchdog)
+
+    server.run_cmd(
+        types.SimpleNamespace(
+            verbose=False,
+            code=False,
+            transport="streamable-http",
+            port=4042,
+        )
+    )
+
+    assert order == ["watchdog", "setup"]
+    assert calls["kw"] == {
+        "transport": "streamable-http",
+        "show_banner": False,
+        "port": 4042,
+    }
+
+
 def test_run_cmd(monkeypatch):
     calls = {}
 
@@ -94,6 +203,7 @@ def test_run_cmd(monkeypatch):
         return Dummy()
 
     monkeypatch.setattr(server, "setup_server", fake_setup_server)
+    monkeypatch.setattr(server, "_start_parent_watchdog", lambda: None)
     monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
     server.run_cmd(types.SimpleNamespace(verbose=True, code=False, transport="stdio", port=None))
     assert calls["setup_called"]
@@ -110,6 +220,7 @@ def test_run_cmd__streamable_http_with_port(monkeypatch):
             calls["kw"] = kw
 
     monkeypatch.setattr(server, "setup_server", lambda code=False: Dummy())
+    monkeypatch.setattr(server, "_start_parent_watchdog", lambda: None)
     server.run_cmd(
         types.SimpleNamespace(
             verbose=False,


### PR DESCRIPTION
Start a parent-death watchdog before server setup so conda-meta-mcp terminates itself if the launching MCP host/proxy process exits without graceful shutdown. This prevents stale stdio or streamable-http server processes from surviving client shutdown and holding ports such as 4042.

This is a defensive workaround for upstream lifecycle gaps where MCP hosts or proxy runners may forcefully terminate the stdio parent without cleaning up descendants.

Related upstream issues:
- https://github.com/modelcontextprotocol/python-sdk/issues/526
- https://github.com/modelcontextprotocol/python-sdk/issues/2231
- https://github.com/PrefectHQ/fastmcp/issues/353
- https://github.com/anthropics/claude-code/issues/1935
- https://github.com/modelcontextprotocol/typescript-sdk/issues/2023
- https://github.com/modelcontextprotocol/typescript-sdk/issues/2002
- https://github.com/microsoft/vscode/issues/316266