### PR TITLE
Add conda completion manifest command tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Currently available:
 - File path to package mapping via the `file_path_search` tool
 - PyPI name to conda package mapping via the `pypi_to_conda` tool
 - CLI help (for conda) via the `cli_help` tool
+- Structured conda CLI command metadata from conda-completion's cache via the
+  `conda_cli_command` tool
 - Repository metadata queries (depends / whoneeds) via the `repoquery` tool
 
 Tools backed by channel-specific data sources require an explicit `channel` argument and

--- a/conda_meta_mcp/tools/conda_cli.py
+++ b/conda_meta_mcp/tools/conda_cli.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Self
+
+import msgpack
+from fastmcp.exceptions import ToolError
+
+from .registry import register_tool
+
+MAX_MSGPACK_FILE_SIZE = 50 * 1024 * 1024
+MAX_COLLECTION_SIZE = 2_000_000
+
+
+@dataclass(frozen=True)
+class CompletionManifestReader:
+    cache_dir: Path
+
+    @classmethod
+    def from_environment(cls) -> Self:
+        override = os.environ.get("CONDA_COMPLETION_CACHE_DIR")
+        if override:
+            return cls(Path(os.path.expandvars(override)).expanduser().resolve())
+        if sys.platform == "win32":
+            base = os.environ.get("LOCALAPPDATA")
+            if base:
+                return cls(Path(base) / "conda" / "cache" / "completion")
+            return cls(Path.home() / "AppData" / "Local" / "conda" / "cache" / "completion")
+        if sys.platform == "darwin":
+            return cls(Path.home() / "Library" / "Caches" / "conda" / "completion")
+        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+        return cls(base / "conda" / "completion")
+
+    def read_manifest(self) -> tuple[Path, dict[str, Any]]:
+        path = self.cache_dir / "completion.msgpack"
+        try:
+            if path.is_symlink():
+                raise ToolError(f"[cache_error] Refusing to read symlink: {path.name}")
+            size = path.stat().st_size
+            if size > MAX_MSGPACK_FILE_SIZE:
+                raise ToolError(f"[cache_error] {path.name} is too large ({size} bytes)")
+            manifest = msgpack.unpackb(
+                path.read_bytes(),
+                max_str_len=MAX_MSGPACK_FILE_SIZE,
+                max_bin_len=MAX_MSGPACK_FILE_SIZE,
+                max_array_len=MAX_COLLECTION_SIZE,
+                max_map_len=MAX_COLLECTION_SIZE,
+            )
+        except FileNotFoundError as exc:
+            raise ToolError(
+                "[not_found] completion.msgpack not found; run 'conda completion generate' first."
+            ) from exc
+        except (msgpack.UnpackException, ValueError) as exc:
+            raise ToolError(f"[cache_error] Failed to decode {path.name}: {exc}") from exc
+        if not isinstance(manifest, dict):
+            raise ToolError("[cache_error] completion.msgpack root is not a mapping")
+        return path, manifest
+
+    def mapping(self, value: Any, field: str) -> dict[str, Any]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ToolError(f"[cache_error] completion.msgpack field is not a mapping: {field}")
+        return value
+
+    def resolve_command(
+        self,
+        manifest: dict[str, Any],
+        command_path: str,
+    ) -> tuple[list[str], list[str], list[str] | None, dict[str, Any]]:
+        try:
+            requested = shlex.split(command_path)
+        except ValueError as exc:
+            raise ToolError(f"[validation_error] Invalid command_path: {exc}") from exc
+        if requested and requested[0] == "conda":
+            requested = requested[1:]
+        if any(part.startswith("-") for part in requested):
+            raise ToolError("[validation_error] command_path must contain commands, not options")
+
+        resolved = list(requested)
+        alias_target = None
+        aliases = self.mapping(manifest.get("aliases"), "aliases")
+        if resolved:
+            alias = aliases.get(resolved[0])
+            if isinstance(alias, dict) and isinstance(alias.get("target"), list):
+                alias_target = [str(item) for item in alias["target"] if str(item)]
+                resolved = [*alias_target, *resolved[1:]]
+
+        commands = self.mapping(manifest.get("commands"), "commands")
+        command: dict[str, Any] = {
+            "summary": None,
+            "options": self.mapping(manifest.get("root_options"), "root_options"),
+            "positionals": [],
+            "subcommands": commands,
+            "exclusive_groups": [],
+        }
+        next_commands = commands
+        visited: list[str] = []
+        for part in resolved:
+            next_command = next_commands.get(part)
+            if not isinstance(next_command, dict):
+                available = ", ".join(sorted(next_commands)[:20])
+                detail = f" Available subcommands: {available}" if available else ""
+                raise ToolError(
+                    f"[not_found] Unknown conda command path: "
+                    f"{' '.join([*visited, part])}.{detail}"
+                )
+            visited.append(part)
+            command = next_command
+            next_commands = self.mapping(command.get("subcommands"), "subcommands")
+        return requested, resolved, alias_target, command
+
+    def command(
+        self,
+        command_path: str = "",
+        include_options: bool = True,
+        include_positionals: bool = True,
+        include_subcommands: bool = True,
+    ) -> dict[str, Any]:
+        manifest_path, manifest = self.read_manifest()
+        requested, resolved, alias_target, command = self.resolve_command(manifest, command_path)
+
+        result: dict[str, Any] = {
+            "command_path": requested,
+            "resolved_command_path": resolved,
+            "alias_target": alias_target,
+            "summary": command.get("summary"),
+            "manifest": {
+                "path": str(manifest_path),
+                "version": manifest.get("version"),
+                "generated_at": manifest.get("generated_at"),
+                "plugin_hash": manifest.get("plugin_hash"),
+            },
+        }
+        if include_options:
+            result["options"] = [
+                {"name": name, **value}
+                if isinstance(value, dict)
+                else {"name": name, "value": value}
+                for name, value in sorted(self.mapping(command.get("options"), "options").items())
+            ]
+        if include_positionals:
+            positionals = command.get("positionals") or []
+            if not isinstance(positionals, list):
+                raise ToolError(
+                    "[cache_error] completion.msgpack field is not a list: positionals"
+                )
+            result["positionals"] = [item for item in positionals if isinstance(item, dict)]
+        if include_subcommands:
+            result["subcommands"] = [
+                {
+                    "name": name,
+                    "summary": value.get("summary") if isinstance(value, dict) else None,
+                }
+                for name, value in sorted(
+                    self.mapping(command.get("subcommands"), "subcommands").items()
+                )
+            ]
+        exclusive_groups = command.get("exclusive_groups")
+        if isinstance(exclusive_groups, list) and exclusive_groups:
+            result["exclusive_groups"] = exclusive_groups
+        return result
+
+
+@register_tool
+async def conda_cli_command(
+    command_path: str = "",
+    include_options: bool = True,
+    include_positionals: bool = True,
+    include_subcommands: bool = True,
+) -> dict[str, Any]:
+    """
+    Read conda-completion's completion.msgpack and return structured conda CLI metadata.
+
+    Args:
+      command_path: Space-separated conda command path, e.g. "", "install", "env list",
+        or "conda install". Empty string returns root command metadata.
+      include_options: Include command options and flag metadata.
+      include_positionals: Include positional argument metadata.
+      include_subcommands: Include direct child subcommands.
+
+    Returns:
+      A dictionary with the resolved command path, summary, selected metadata sections,
+      and completion.msgpack metadata.
+    """
+    try:
+        reader = CompletionManifestReader.from_environment()
+        return await asyncio.to_thread(
+            reader.command,
+            command_path,
+            include_options,
+            include_positionals,
+            include_subcommands,
+        )
+    except ToolError:
+        raise
+    except Exception as e:
+        raise ToolError(f"[unknown_error] 'conda_cli_command' failed: {e}") from e

--- a/pixi.lock
+++ b/pixi.lock
@@ -8736,6 +8736,7 @@ packages:
   - conda-package-streaming>=0.12,<0.14
   - conda>=26.1,<27
   - fastmcp>=3.1.0
+  - msgpack>=1.1
   - pydantic>=2
   - pyyaml>=6.0.3,<7
   - requests>=2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "conda-libmamba-solver",
   "conda-package-streaming>=0.12,<0.14",
   "fastmcp>=3.1.0",
+  "msgpack>=1.1",
   "pydantic>=2",
   "pyyaml>=6.0.3,<7",
   "requests>=2",
@@ -54,6 +55,7 @@ conda-libmamba-solver = "*"
 conda-package-streaming = ">=0.12.0,<0.14"
 fastmcp = ">=3.4.0,<3.5.0"
 libmambapy = ">=2.4.0,<3"
+msgpack-python = ">=1.1"
 pydantic-monty = "*"
 pyyaml = ">=6.0.3,<7"
 requests = ">=2,<3"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - conda-forge-metadata >=0.15.0,<0.17
     - conda-package-streaming >=0.12.0
     - conda-libmamba-solver
+    - msgpack-python >=1.1
     - pydantic-monty
     - pyyaml >=6.0.3
     - requests >=2.28.0

--- a/server-info.json
+++ b/server-info.json
@@ -94,6 +94,49 @@
       "execution": null
     },
     {
+      "name": "conda_cli_command",
+      "title": null,
+      "description": "Read conda-completion's completion.msgpack and return structured conda CLI metadata.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "command_path": {
+            "default": "",
+            "type": "string",
+            "description": "Space-separated conda command path, e.g. \"\", \"install\", \"env list\",\nor \"conda install\". Empty string returns root command metadata."
+          },
+          "include_options": {
+            "default": true,
+            "type": "boolean",
+            "description": "Include command options and flag metadata."
+          },
+          "include_positionals": {
+            "default": true,
+            "type": "boolean",
+            "description": "Include positional argument metadata."
+          },
+          "include_subcommands": {
+            "default": true,
+            "type": "boolean",
+            "description": "Include direct child subcommands."
+          }
+        },
+        "type": "object"
+      },
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "icons": null,
+      "annotations": null,
+      "_meta": {
+        "fastmcp": {
+          "tags": []
+        }
+      },
+      "execution": null
+    },
+    {
       "name": "file_path_search",
       "title": null,
       "description": "Find conda artifacts that contain an exact file path.\n\nSearches package path metadata for packages that ship the specified path.\nRequires the full path as it exists within the package (exact match only).",

--- a/tests/tools/test_conda_cli.py
+++ b/tests/tools/test_conda_cli.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import msgpack
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+
+def write_completion_cache(tmp_path):
+    manifest = {
+        "version": 1,
+        "generated_at": "2026-06-14T12:00:00+00:00",
+        "plugin_hash": "abc123",
+        "root_options": {
+            "--json": {
+                "description": "Report all output as json.",
+                "nargs": "0",
+            }
+        },
+        "commands": {
+            "env": {
+                "summary": "Manage conda environments.",
+                "subcommands": {
+                    "list": {
+                        "summary": "List conda environments.",
+                        "options": {
+                            "--name": {
+                                "short": "-n",
+                                "completion_type": "env_name",
+                            }
+                        },
+                        "positionals": [],
+                        "subcommands": {},
+                    }
+                },
+            },
+            "install": {
+                "summary": "Install packages.",
+                "options": {
+                    "--channel": {
+                        "short": "-c",
+                        "completion_type": "channel",
+                    }
+                },
+                "positionals": [
+                    {
+                        "name": "packages",
+                        "completion_type": "package_spec",
+                        "nargs": "*",
+                    }
+                ],
+                "subcommands": {},
+            },
+        },
+        "aliases": {
+            "i": {
+                "target": ["install"],
+            }
+        },
+        "package_names": ["numpy", "numpy-base", "pandas", "python-numpy"],
+    }
+    (tmp_path / "completion.msgpack").write_bytes(msgpack.packb(manifest))
+
+
+@pytest.mark.asyncio
+async def test_conda_cli_command__root_metadata(server, tmp_path, monkeypatch):
+    write_completion_cache(tmp_path)
+    monkeypatch.setenv("CONDA_COMPLETION_CACHE_DIR", str(tmp_path))
+
+    async with Client(server) as client:
+        result = await client.call_tool("conda_cli_command", {})
+
+    assert result.data["command_path"] == []
+    assert result.data["resolved_command_path"] == []
+    assert result.data["manifest"]["version"] == 1
+    assert result.data["options"] == [
+        {
+            "name": "--json",
+            "description": "Report all output as json.",
+            "nargs": "0",
+        }
+    ]
+    assert result.data["subcommands"] == [
+        {"name": "env", "summary": "Manage conda environments."},
+        {"name": "install", "summary": "Install packages."},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_conda_cli_command__nested_command(server, tmp_path, monkeypatch):
+    write_completion_cache(tmp_path)
+    monkeypatch.setenv("CONDA_COMPLETION_CACHE_DIR", str(tmp_path))
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "conda_cli_command",
+            {
+                "command_path": "conda env list",
+                "include_subcommands": False,
+            },
+        )
+
+    assert result.data["command_path"] == ["env", "list"]
+    assert result.data["resolved_command_path"] == ["env", "list"]
+    assert result.data["summary"] == "List conda environments."
+    assert result.data["options"] == [
+        {
+            "name": "--name",
+            "short": "-n",
+            "completion_type": "env_name",
+        }
+    ]
+    assert "subcommands" not in result.data
+
+
+@pytest.mark.asyncio
+async def test_conda_cli_command__resolves_alias(server, tmp_path, monkeypatch):
+    write_completion_cache(tmp_path)
+    monkeypatch.setenv("CONDA_COMPLETION_CACHE_DIR", str(tmp_path))
+
+    async with Client(server) as client:
+        result = await client.call_tool("conda_cli_command", {"command_path": "i"})
+
+    assert result.data["command_path"] == ["i"]
+    assert result.data["resolved_command_path"] == ["install"]
+    assert result.data["alias_target"] == ["install"]
+    assert result.data["summary"] == "Install packages."
+
+
+@pytest.mark.asyncio
+async def test_conda_cli_command__unknown_command_error(server, tmp_path, monkeypatch):
+    write_completion_cache(tmp_path)
+    monkeypatch.setenv("CONDA_COMPLETION_CACHE_DIR", str(tmp_path))
+
+    with pytest.raises(ToolError, match="Unknown conda command path"):
+        async with Client(server) as client:
+            await client.call_tool("conda_cli_command", {"command_path": "does-not-exist"})
+
+
+@pytest.mark.asyncio
+async def test_conda_cli_command__missing_completion_cache_error(server, tmp_path, monkeypatch):
+    monkeypatch.setenv("CONDA_COMPLETION_CACHE_DIR", str(tmp_path))
+
+    with pytest.raises(ToolError, match=r"completion\.msgpack not found"):
+        async with Client(server) as client:
+            await client.call_tool("conda_cli_command", {})


### PR DESCRIPTION
## Summary
- Add `conda_cli_command`, a read-only MCP tool that reads conda-completion's `completion.msgpack` and returns structured command metadata.
- Include options, positionals, subcommands, aliases, and manifest metadata for a requested conda command path.
- Update tool schema metadata, docs, package metadata, lockfile, and tests.

## Notes
@dbast, could you consider whether this belongs in conda-meta-mcp? I kept package-name and package-version cache tools out for now because they overlap with existing package metadata tools, but we could add `conda_cli_packages` and `conda_cli_package_versions` as fast local/offline conda-completion-backed lookups if that feels useful.

## Validation
- `pixi run test tests/tools/test_conda_cli.py`
- `pixi run test`
- `pixi run prek` passed all substantive hooks; the final `git-diff` hook reported unrelated pre-existing `.gitattributes` / `.git_archival.txt` working-tree changes.